### PR TITLE
Update peek and resque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@
 # 2.0.1
 
 - Add auto-gravity for tooltips.
+
+# 2.1.0
+
+- Update dependencies to work with latest resque and peek.

--- a/lib/peek-resque/version.rb
+++ b/lib/peek-resque/version.rb
@@ -1,5 +1,5 @@
 module Peek
   module Resque
-    VERSION = '2.0.1'
+    VERSION = '2.1.0'
   end
 end

--- a/peek-resque.gemspec
+++ b/peek-resque.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'peek', '>= 0.1.0'
-  gem.add_dependency 'resque'
+  gem.add_dependency 'peek', '~> 1.0'
+  gem.add_dependency 'resque', '~> 1.27'
 end


### PR DESCRIPTION
Apps using the latest versions of peek and resque fail to load if peek-resque is installed – this PR prevents version clashes.